### PR TITLE
Update compose to 1.6.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@
 QR-Code (or other 2D/3D-Codes, see below) Scanner for Compose Multiplatform (Android/iOS).
 Currently, the implementation is rather rudimentary.
 
+Supported Compose version:
+
+Compose version | EasyQRScan Version
+------------------|-------------------
+1.6.x             | 0.1.x
+1.7               | Not yet supported
+
 # Dependency
 Add the dependency to your commonMain sourceSet (KMP) / Android dependencies (android only):
 ```kotlin
-implementation("io.github.kalinjul.easyqrscan:scanner:0.1.3")
+implementation("io.github.kalinjul.easyqrscan:scanner:0.1.5")
 ```
 
 Or, for your libs.versions.toml:
 ```toml
 [versions]
-easyqrscan = "0.1.3"
+easyqrscan = "0.1.5"
 [libraries]
 easyqrscan = { module = "io.github.kalinjul.easyqrscan:scanner", version.ref = "easyqrscan" }
 ```

--- a/build-logic/convention/src/main/kotlin/org/publicvalue/convention/config/Android.kt
+++ b/build-logic/convention/src/main/kotlin/org/publicvalue/convention/config/Android.kt
@@ -9,7 +9,7 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.the
 import java.io.File
 
-fun Project.configureKotlinAndroid(extension: CommonExtension<*, *, *, *, *>) {
+fun Project.configureKotlinAndroid(extension: CommonExtension<*, *, *, *, *, *>) {
     val libs = the<LibrariesForLibs>()
 
     if (extension is LibraryExtension) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "21"
 
 jvmTarget = "17"
 # https://developer.android.com/build/releases/gradle-plugin#compatibility
-agp = "8.2.2"
+agp = "8.4.2"
 
 #https://github.com/JetBrains/compose-multiplatform
 compose-multiplatform = "1.6.11"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ jvmTarget = "17"
 agp = "8.2.2"
 
 #https://github.com/JetBrains/compose-multiplatform
-compose-multiplatform = "1.6.0"
+compose-multiplatform = "1.6.11"
 kotlin = "1.9.22"
 # https://github.com/google/ksp
 ksp = "1.9.22-1.0.17"
@@ -17,15 +17,15 @@ ksp = "1.9.22-1.0.17"
 #composeCompiler = "1.5.8.1"
 
 # https://developer.android.com/jetpack/androidx/releases/activity
-androidxActivity = "1.8.2"
+androidxActivity = "1.9.0"
 # https://developer.android.com/jetpack/androidx/releases/appcompat
-androidxAppCompat = "1.6.1"
-coreKtx = "1.12.0"
+androidxAppCompat = "1.7.0"
+coreKtx = "1.13.1"
 
 dokka = "1.9.10"
 nexus-publish-plugin = "1.3.0"
 accompanist = "0.34.0"
-androidxCamera = "1.3.2"
+androidxCamera = "1.3.3"
 mlkit = "17.2.0"
 
 [libraries]

--- a/sample-app/shared/src/commonMain/kotlin/MainView.kt
+++ b/sample-app/shared/src/commonMain/kotlin/MainView.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 import org.publicvalue.multiplatform.qrcode.CodeType
 import org.publicvalue.multiplatform.qrcode.ScannerWithPermissions
@@ -27,7 +26,7 @@ fun MainView() {
         }
         if (scannerVisible) {
             ScannerWithPermissions(
-                modifier = Modifier.padding(16.dp).clipToBounds(),
+                modifier = Modifier.padding(16.dp),
                 onScanned = { println(it); true }, types = listOf(CodeType.QR)
             )
         }

--- a/scanner/src/androidMain/kotlin/BarcodeAnalyzer.kt
+++ b/scanner/src/androidMain/kotlin/BarcodeAnalyzer.kt
@@ -1,8 +1,6 @@
 package org.publicvalue.multiplatform.qrcode
 
 import android.annotation.SuppressLint
-import android.content.Context
-import android.widget.Toast
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions

--- a/scanner/src/iosMain/kotlin/ScannerView.kt
+++ b/scanner/src/iosMain/kotlin/ScannerView.kt
@@ -1,5 +1,6 @@
 package org.publicvalue.multiplatform.qrcode
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
@@ -73,7 +74,7 @@ fun UiScannerView(
     }
 
     UIKitView(
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
         background = Color.Black,
         factory = {
             val previewContainer = UIView()


### PR DESCRIPTION
- update compose to 1.6.11
- use fillMaxSize on iOS by default as compose 1.6.10+ respects UIKitView sizes now
- update dependencies