### PR TITLE
iOS non-QR code type fix

### DIFF
--- a/scanner/src/iosMain/kotlin/Codetype+toFormat.kt
+++ b/scanner/src/iosMain/kotlin/Codetype+toFormat.kt
@@ -13,7 +13,7 @@ import platform.AVFoundation.AVMetadataObjectTypePDF417Code
 import platform.AVFoundation.AVMetadataObjectTypeQRCode
 import platform.AVFoundation.AVMetadataObjectTypeUPCECode
 
-private fun List<CodeType>.toFormat(): List<platform.AVFoundation.AVMetadataObjectType> = map {
+fun List<CodeType>.toFormat(): List<platform.AVFoundation.AVMetadataObjectType> = map {
     when(it) {
         CodeType.Codabar -> AVMetadataObjectTypeCodabarCode
         CodeType.Code39 -> AVMetadataObjectTypeCode39Code

--- a/scanner/src/iosMain/kotlin/Scanner.ios.kt
+++ b/scanner/src/iosMain/kotlin/Scanner.ios.kt
@@ -26,7 +26,8 @@ actual fun Scanner(
         modifier = modifier,
         onScanned = {
             onScanned(it)
-        }
+        },
+        allowedMetadataTypes = types.toFormat()
     )
 }
 

--- a/scanner/src/iosMain/kotlin/ScannerView.kt
+++ b/scanner/src/iosMain/kotlin/ScannerView.kt
@@ -51,7 +51,7 @@ import platform.darwin.dispatch_get_main_queue
 fun UiScannerView(
     modifier: Modifier = Modifier,
     // https://developer.apple.com/documentation/avfoundation/avmetadataobjecttype?language=objc
-    allowedMetadataTypes: List<AVMetadataObjectType> = listOf(AVMetadataObjectTypeQRCode),
+    allowedMetadataTypes: List<AVMetadataObjectType>,
     onScanned: (String) -> Boolean
 ) {
     val coordinator = remember {


### PR DESCRIPTION
Set the UiScannerView to use the passed types CodeType variable along with making the "CodeType.toFormat" function public.

It looks like the default UiScannerView was being instantiated without referencing the user passed types, and only the QR code type. 

I wasn't able to compile to mavenLocal and I didn't find an easily runnable iOS sample app to test, so this is _untested_. Feel free to make any modifications or let me know if I missed something.