### PR TITLE
fix: add warning if codebar is used on iOS < 15.4

### DIFF
--- a/scanner/src/iosMain/kotlin/Codetype+toFormat.kt
+++ b/scanner/src/iosMain/kotlin/Codetype+toFormat.kt
@@ -15,7 +15,7 @@ import platform.AVFoundation.AVMetadataObjectTypeUPCECode
 
 fun List<CodeType>.toFormat(): List<platform.AVFoundation.AVMetadataObjectType> = map {
     when(it) {
-        CodeType.Codabar -> AVMetadataObjectTypeCodabarCode
+        CodeType.Codabar -> if (iosVersionIsMin(15,4)) { AVMetadataObjectTypeCodabarCode } else error("AVMetadataObjectTypeCodabarCode not available on iOS ${iosVersion()}")
         CodeType.Code39 -> AVMetadataObjectTypeCode39Code
         CodeType.Code93 -> AVMetadataObjectTypeCode93Code
         CodeType.Code128 -> AVMetadataObjectTypeCode128Code

--- a/scanner/src/iosMain/kotlin/IosVersion.kt
+++ b/scanner/src/iosMain/kotlin/IosVersion.kt
@@ -1,0 +1,13 @@
+package org.publicvalue.multiplatform.qrcode
+
+import platform.UIKit.UIDevice
+
+fun iosVersion() = UIDevice.currentDevice.systemVersion
+fun iosVersionIsMin(major: Int, minor: Int) = iosVersion()
+    .split('.')
+    .map { it.toIntOrNull() ?: 0 }
+    .let {
+        val systemMajor = it.getOrElse(0) { 0 }
+        val systemMinor = it.getOrElse(1) { 0 }
+        systemMajor > major || systemMajor == major && systemMinor >= minor
+    }


### PR DESCRIPTION
Adds better error message for crash mentioned in #7.
Codabar is only available on iOS >= 15.4