### PR TITLE
Ability to toggle camera and set a defaultOrientation

### DIFF
--- a/sample-app/shared/src/commonMain/kotlin/MainView.kt
+++ b/sample-app/shared/src/commonMain/kotlin/MainView.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import org.publicvalue.multiplatform.qrcode.CameraOrientation
 import org.publicvalue.multiplatform.qrcode.CameraPosition
 import org.publicvalue.multiplatform.qrcode.CodeType
 import org.publicvalue.multiplatform.qrcode.ScannerWithPermissions
@@ -34,10 +35,16 @@ fun MainView() {
         Column(modifier = Modifier.padding(it)) {
             Text("Scan QR-Code below")
             var scannerVisible by remember {mutableStateOf(false)}
+            var cameraPosition by remember { mutableStateOf( CameraPosition.BACK)}
             Button(onClick = {
                 scannerVisible = !scannerVisible
             }) {
                 Text("Toggle scanner (visible: $scannerVisible)")
+            }
+            Button(onClick = {
+                cameraPosition = if(cameraPosition== CameraPosition.BACK) CameraPosition.FRONT else CameraPosition.BACK
+            }) {
+                Text("Toggle camera (position: $cameraPosition)")
             }
             if (scannerVisible) {
                 val scope = rememberCoroutineScope()
@@ -50,7 +57,8 @@ fun MainView() {
                         false // continue scanning
                     },
                     types = listOf(CodeType.QR),
-                    cameraPosition = CameraPosition.BACK
+                    cameraPosition = cameraPosition,
+                    defaultOrientation = CameraOrientation.LANDSCAPE
                 )
             }
         }

--- a/scanner/src/androidMain/kotlin/Scanner.android.kt
+++ b/scanner/src/androidMain/kotlin/Scanner.android.kt
@@ -20,11 +20,12 @@ actual fun Scanner(
     onScanned: (String) -> Boolean,
     types: List<CodeType>,
     cameraPosition: CameraPosition,
+    defaultOrientation: CameraOrientation?
 ) {
     val analyzer = remember() {
         BarcodeAnalyzer(types.toFormat(), onScanned)
     }
-    CameraView(modifier, analyzer, cameraPosition)
+    CameraView(modifier, analyzer, cameraPosition, defaultOrientation)
 }
 
 @OptIn(ExperimentalPermissionsApi::class)

--- a/scanner/src/androidMain/kotlin/ScannerView.kt
+++ b/scanner/src/androidMain/kotlin/ScannerView.kt
@@ -1,7 +1,8 @@
 package org.publicvalue.multiplatform.qrcode
 
 import android.util.Log
-import android.widget.LinearLayout
+import android.view.Surface.ROTATION_0
+import android.view.Surface.ROTATION_180
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
@@ -9,6 +10,7 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -20,46 +22,53 @@ import androidx.core.content.ContextCompat
 fun CameraView(
     modifier: Modifier = Modifier,
     analyzer: BarcodeAnalyzer,
-    cameraPosition: CameraPosition
+    cameraPosition: CameraPosition,
+    defaultOrientation: CameraOrientation?
 ) {
     val localContext = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val cameraProviderFuture = remember {
         ProcessCameraProvider.getInstance(localContext)
     }
+    val previewView = remember { PreviewView(localContext) }
+
+    LaunchedEffect(cameraPosition) {
+        val preview = when (defaultOrientation) {
+            CameraOrientation.LANDSCAPE -> Preview.Builder().setTargetRotation(ROTATION_180).build()
+            CameraOrientation.PORTRAIT -> Preview.Builder().setTargetRotation(ROTATION_0).build()
+            null -> Preview.Builder().build()
+        }
+        val selector = CameraSelector.Builder()
+            .let {
+                when (cameraPosition) {
+                    CameraPosition.FRONT -> it.requireLensFacing(CameraSelector.LENS_FACING_FRONT)
+                    CameraPosition.BACK -> it.requireLensFacing(CameraSelector.LENS_FACING_BACK)
+                }
+            }.build()
+        preview.setSurfaceProvider(previewView.surfaceProvider)
+
+        val imageAnalysis = ImageAnalysis.Builder().build()
+        imageAnalysis.setAnalyzer(
+            ContextCompat.getMainExecutor(localContext),
+            analyzer
+        )
+
+        runCatching {
+            cameraProviderFuture.get().unbindAll()
+            cameraProviderFuture.get().bindToLifecycle(
+                lifecycleOwner,
+                selector,
+                preview,
+                imageAnalysis
+            )
+        }.onFailure {
+            Log.e("CAMERA", "Camera bind error ${it.localizedMessage}", it)
+        }
+    }
+
     AndroidView(
         modifier = modifier.fillMaxSize(),
         factory = { context ->
-            val previewView = PreviewView(context)
-            val preview = Preview.Builder().build()
-            val selector = CameraSelector.Builder()
-                .let {
-                    when (cameraPosition) {
-                        CameraPosition.FRONT -> it.requireLensFacing(CameraSelector.LENS_FACING_FRONT)
-                        CameraPosition.BACK -> it.requireLensFacing(CameraSelector.LENS_FACING_BACK)
-                    }
-                }
-                .build()
-
-            preview.setSurfaceProvider(previewView.surfaceProvider)
-
-            val imageAnalysis = ImageAnalysis.Builder().build()
-            imageAnalysis.setAnalyzer(
-                ContextCompat.getMainExecutor(context),
-                analyzer
-            )
-
-            runCatching {
-                cameraProviderFuture.get().unbindAll()
-                cameraProviderFuture.get().bindToLifecycle(
-                    lifecycleOwner,
-                    selector,
-                    preview,
-                    imageAnalysis
-                )
-            }.onFailure {
-                Log.e("CAMERA", "Camera bind error ${it.localizedMessage}", it)
-            }
             previewView
         }
     )

--- a/scanner/src/commonMain/kotlin/CameraOrientation.kt
+++ b/scanner/src/commonMain/kotlin/CameraOrientation.kt
@@ -1,0 +1,6 @@
+package org.publicvalue.multiplatform.qrcode
+
+enum class CameraOrientation {
+    LANDSCAPE,
+    PORTRAIT
+}

--- a/scanner/src/commonMain/kotlin/Scanner.kt
+++ b/scanner/src/commonMain/kotlin/Scanner.kt
@@ -24,7 +24,8 @@ expect fun Scanner(
     modifier: Modifier = Modifier,
     onScanned: (String) -> Boolean,
     types: List<CodeType>,
-    cameraPosition: CameraPosition = CameraPosition.BACK
+    cameraPosition: CameraPosition = CameraPosition.BACK,
+    defaultOrientation: CameraOrientation? = null
 )
 
 /**
@@ -45,6 +46,7 @@ fun ScannerWithPermissions(
     cameraPosition: CameraPosition = CameraPosition.BACK,
     permissionText: String = "Camera is required for QR Code scanning",
     openSettingsLabel: String = "Open Settings",
+    defaultOrientation: CameraOrientation?
 ) {
     ScannerWithPermissions(
         modifier = modifier.clipToBounds(),
@@ -61,7 +63,8 @@ fun ScannerWithPermissions(
                     Text(openSettingsLabel)
                 }
             }
-        }
+        },
+        defaultOrientation
     )
 }
 
@@ -81,6 +84,7 @@ fun ScannerWithPermissions(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     permissionDeniedContent: @Composable (CameraPermissionState) -> Unit,
+    defaultOrientation: CameraOrientation?
 ) {
     val permissionState = rememberCameraPermissionState()
 
@@ -91,7 +95,7 @@ fun ScannerWithPermissions(
     }
 
     if (permissionState.status == CameraPermissionStatus.Granted) {
-        Scanner(modifier, types = types, onScanned = onScanned, cameraPosition = cameraPosition)
+        Scanner(modifier, types = types, onScanned = onScanned, cameraPosition = cameraPosition, defaultOrientation = defaultOrientation)
     } else {
         permissionDeniedContent(permissionState)
     }

--- a/scanner/src/iosMain/kotlin/Scanner.ios.kt
+++ b/scanner/src/iosMain/kotlin/Scanner.ios.kt
@@ -20,7 +20,8 @@ actual fun Scanner(
     modifier: Modifier,
     onScanned: (String) -> Boolean, // return true to abort scanning
     types: List<CodeType>,
-    cameraPosition: CameraPosition
+    cameraPosition: CameraPosition,
+    defaultOrientation: CameraOrientation?
 ) {
     UiScannerView(
         modifier = modifier,
@@ -28,7 +29,8 @@ actual fun Scanner(
             onScanned(it)
         },
         allowedMetadataTypes = types.toFormat(),
-        cameraPosition = cameraPosition
+        cameraPosition = cameraPosition,
+        defaultOrientation = defaultOrientation
     )
 }
 


### PR DESCRIPTION
Features Added: 1. Ability to toggle the camera front and back 2. Setting a default orientation so that the orientation looks correct when a capture session is started in iPad (which should be landscape, which becomes portrait sometimes). Updated the sample project accordingly.

Problem:
In iPad, when the app is in landscape mode, the orientation starts in portrait instead of landscape.

https://github.com/user-attachments/assets/390dd7c4-d206-4707-8d25-dc6aea92df18

