### PR TITLE
Add fixed scanner orientation for locked host interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ ScannerWithPermissions(
 Scanner(onScanned = { println(it); true }, types = listOf(CodeType.QR))
 ```
 
+The scanner follows physical device rotation by default. For an app with a locked
+interface orientation, pass a fixed `ScannerOrientation` to keep the camera preview
+from rotating with the device:
+
+```kotlin
+ScannerWithPermissions(
+    onScanned = { println(it); true },
+    types = listOf(CodeType.QR),
+    enableTorch = false,
+    orientation = ScannerOrientation.LandscapeRight,
+)
+```
+
 Check out the [sample app](./sample-app) included in the repository.
 
 # Code Types

--- a/scanner/src/androidMain/kotlin/Scanner.android.kt
+++ b/scanner/src/androidMain/kotlin/Scanner.android.kt
@@ -21,6 +21,7 @@ actual fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     enableTorch: Boolean,
+    orientation: ScannerOrientation,
 ) {
     val analyzer = remember() {
         BarcodeAnalyzer(types.toFormat(), onScanned)

--- a/scanner/src/commonMain/kotlin/Scanner.kt
+++ b/scanner/src/commonMain/kotlin/Scanner.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.dp
  * @param onScanned Called when a code was scanned. The given lambda should return true
  *                  if scanning was successful and scanning should be aborted.
  *                  Return false if scanning should continue.
+ * @param orientation Orientation used by the camera preview. `Device` follows physical
+ *                    device rotation; the other values keep the preview fixed.
  */
 @Composable
 expect fun Scanner(
@@ -26,6 +28,7 @@ expect fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition = CameraPosition.BACK,
     enableTorch: Boolean,
+    orientation: ScannerOrientation = ScannerOrientation.Device,
 )
 
 /**
@@ -37,6 +40,7 @@ expect fun Scanner(
  *                  Return false if scanning should continue.
  * @param permissionText Text to show if permission was denied.
  * @param openSettingsLabel Label to show on the "Go to settings" Button
+ * @param orientation Orientation used by the camera preview.
  */
 @Composable
 fun ScannerWithPermissions(
@@ -47,6 +51,7 @@ fun ScannerWithPermissions(
     enableTorch: Boolean,
     permissionText: String = "Camera is required for QR Code scanning",
     openSettingsLabel: String = "Open Settings",
+    orientation: ScannerOrientation = ScannerOrientation.Device,
 ) {
     ScannerWithPermissions(
         modifier = modifier.clipToBounds(),
@@ -54,6 +59,7 @@ fun ScannerWithPermissions(
         types = types,
         cameraPosition = cameraPosition,
         enableTorch = enableTorch,
+        orientation = orientation,
         permissionDeniedContent = { permissionState ->
             Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
@@ -76,6 +82,7 @@ fun ScannerWithPermissions(
  *                  if scanning was successful and scanning should be aborted.
  *                  Return false if scanning should continue.
  * @param permissionDeniedContent Content to show if permission was denied.
+ * @param orientation Orientation used by the camera preview.
  */
 @Composable
 fun ScannerWithPermissions(
@@ -84,6 +91,7 @@ fun ScannerWithPermissions(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     enableTorch: Boolean,
+    orientation: ScannerOrientation = ScannerOrientation.Device,
     permissionDeniedContent: @Composable (CameraPermissionState) -> Unit,
 ) {
     val permissionState = rememberCameraPermissionState()
@@ -95,7 +103,14 @@ fun ScannerWithPermissions(
     }
 
     if (permissionState.status == CameraPermissionStatus.Granted) {
-        Scanner(modifier, types = types, onScanned = onScanned, cameraPosition = cameraPosition, enableTorch = enableTorch)
+        Scanner(
+            modifier,
+            types = types,
+            onScanned = onScanned,
+            cameraPosition = cameraPosition,
+            enableTorch = enableTorch,
+            orientation = orientation,
+        )
     } else {
         permissionDeniedContent(permissionState)
     }

--- a/scanner/src/commonMain/kotlin/ScannerOrientation.kt
+++ b/scanner/src/commonMain/kotlin/ScannerOrientation.kt
@@ -1,0 +1,14 @@
+package org.publicvalue.multiplatform.qrcode
+
+/**
+ * Controls how the scanner preview is oriented.
+ *
+ * [Device] follows physical device rotation. The other values keep the preview fixed.
+ */
+enum class ScannerOrientation {
+    Device,
+    LandscapeLeft,
+    LandscapeRight,
+    Portrait,
+    PortraitUpsideDown,
+}

--- a/scanner/src/iosMain/kotlin/Scanner.ios.kt
+++ b/scanner/src/iosMain/kotlin/Scanner.ios.kt
@@ -24,6 +24,7 @@ actual fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     enableTorch: Boolean,
+    orientation: ScannerOrientation,
 ) {
     var started by remember { mutableStateOf(false) }
     val cameraUtils = rememberCameraUtils()
@@ -44,6 +45,7 @@ actual fun Scanner(
         },
         allowedMetadataTypes = types.toFormat(),
         cameraPosition = cameraPosition,
+        orientation = orientation,
         onStarted = {
             cameraUtils.setTorchMode(cameraPosition, enableTorch)
             started = true

--- a/scanner/src/iosMain/kotlin/ScannerView.kt
+++ b/scanner/src/iosMain/kotlin/ScannerView.kt
@@ -51,6 +51,7 @@ fun UiScannerView(
     // https://developer.apple.com/documentation/avfoundation/avmetadataobjecttype?language=objc
     allowedMetadataTypes: List<AVMetadataObjectType>,
     cameraPosition: CameraPosition,
+    orientation: ScannerOrientation,
     onScanned: (String) -> Boolean,
     onStarted: () -> Unit,
 ) {
@@ -58,19 +59,22 @@ fun UiScannerView(
         ScannerCameraCoordinator(
             onScanned = onScanned,
             cameraPosition = cameraPosition,
+            orientation = orientation,
             onStarted = onStarted
         )
     }
 
-    DisposableEffect(Unit) {
-        val listener = OrientationListener { orientation ->
-            coordinator.setCurrentOrientation(orientation)
+    DisposableEffect(orientation) {
+        val listener = if (orientation == ScannerOrientation.Device) {
+            OrientationListener { deviceOrientation ->
+                coordinator.setCurrentOrientation(deviceOrientation)
+            }.also { it.register() }
+        } else {
+            null
         }
 
-        listener.register()
-
         onDispose {
-            listener.unregister()
+            listener?.unregister()
             // stop capture
             coordinator.captureSession.stopRunning()
         }
@@ -107,7 +111,8 @@ class ScannerPreviewView(private val coordinator: ScannerCameraCoordinator): UIV
 class ScannerCameraCoordinator(
     val onScanned: (String) -> Boolean,
     val onStarted: () -> Unit,
-    val cameraPosition: CameraPosition
+    val cameraPosition: CameraPosition,
+    val orientation: ScannerOrientation,
 ): AVCaptureMetadataOutputObjectsDelegateProtocol, NSObject() {
 
     private var previewLayer: AVCaptureVideoPreviewLayer? = null
@@ -165,17 +170,27 @@ class ScannerCameraCoordinator(
     }
 
     fun setCurrentOrientation(newOrientation: UIDeviceOrientation) {
-        when(newOrientation) {
-            UIDeviceOrientation.UIDeviceOrientationLandscapeLeft ->
-                previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationLandscapeRight
-            UIDeviceOrientation.UIDeviceOrientationLandscapeRight ->
+        when (orientation) {
+            ScannerOrientation.Device -> when(newOrientation) {
+                UIDeviceOrientation.UIDeviceOrientationLandscapeLeft ->
+                    previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationLandscapeRight
+                UIDeviceOrientation.UIDeviceOrientationLandscapeRight ->
+                    previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationLandscapeLeft
+                UIDeviceOrientation.UIDeviceOrientationPortrait ->
+                    previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationPortrait
+                UIDeviceOrientation.UIDeviceOrientationPortraitUpsideDown ->
+                    previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationPortraitUpsideDown
+                else ->
+                    previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationPortrait
+            }
+            ScannerOrientation.LandscapeLeft ->
                 previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationLandscapeLeft
-            UIDeviceOrientation.UIDeviceOrientationPortrait ->
+            ScannerOrientation.LandscapeRight ->
+                previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationLandscapeRight
+            ScannerOrientation.Portrait ->
                 previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationPortrait
-            UIDeviceOrientation.UIDeviceOrientationPortraitUpsideDown ->
+            ScannerOrientation.PortraitUpsideDown ->
                 previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationPortraitUpsideDown
-            else ->
-                previewLayer?.connection?.videoOrientation = AVCaptureVideoOrientationPortrait
         }
     }
 

--- a/scanner/src/jvmMain/kotlin/Scanner.jvm.kt
+++ b/scanner/src/jvmMain/kotlin/Scanner.jvm.kt
@@ -11,6 +11,7 @@ actual fun Scanner(
     types: List<CodeType>,
     cameraPosition: CameraPosition,
     enableTorch: Boolean,
+    orientation: ScannerOrientation,
 ) {
     Text("Scanner not implemented for JVM")
 }


### PR DESCRIPTION
## Problem
The iOS scanner listens to `UIDeviceOrientationDidChangeNotification` and rotates its `AVCaptureVideoPreviewLayer` independently of the host app's supported interface orientations. This causes the camera preview to rotate in apps that intentionally lock their interface orientation.

## Solution
- Add `ScannerOrientation` to the public scanner API.
- Preserve the current device-driven behavior by default.
- Allow callers to select a fixed orientation such as `LandscapeRight`.
- Register the device orientation listener only in device-driven mode.
- Document the fixed-orientation usage.

The fix was verified in a Compose Multiplatform iOS app on a physical device with interface rotation locked and device rotation unlocked.

Closes #22
